### PR TITLE
Request the "editable" field to avoid OpenHAB log spam

### DIFF
--- a/openhab2-exporter.py
+++ b/openhab2-exporter.py
@@ -4,7 +4,8 @@ import time
 
 
 def get_metrics():
-    url = urllib.request.urlopen('http://127.0.0.1:8080/rest/items?recursive=false&fields=name,state,type')
+    # Note: "editable" is not used but is requested anyway to work around an OpenHAB log spam bug. See https://community.openhab.org/t/field-editable-is-required-when-getting-items-on-the-rest-api/65094
+    url = urllib.request.urlopen('http://127.0.0.1:8080/rest/items?recursive=false&fields=name,state,type,editable')
     content_bytes = url.read()
     content = content_bytes.decode('utf-8')
 


### PR DESCRIPTION
Due to what looks like a bug in OpenHAB, spurious errors are written to `openhab.log` every time the exporter makes its REST call:

```
[WARN ] [thome.io.rest.internal.DTOMapperImpl] - Field 'editable' could not be eliminated: Can not set boolean field org.eclipse.smarthome.io.rest.core.item.EnrichedItemDTO.editable to null value
```

This commit adds the `editable` field to the list of requested fields in order to work around the issue.

Background: https://community.openhab.org/t/field-editable-is-required-when-getting-items-on-the-rest-api/65094